### PR TITLE
Added Modbus Timeout configuration

### DIFF
--- a/app-dS2832-tija.dsj
+++ b/app-dS2832-tija.dsj
@@ -1,0 +1,1 @@
+{"web":"\/webpage","name":"app-dS2832-tija","files":[{"file":"app-dS2832-v4-14.dsi","compile":true}],"active":"app-dS2832-v4-14.dsi","version":"1","editors":["app-dS2832-v4-14.dsi,224"]}

--- a/app-dS2832-v4-14.dsi
+++ b/app-dS2832-v4-14.dsi
@@ -36,6 +36,7 @@ flstring    System_AD4Name[NAMESIZE]
 flint32     System_ModbusUID
 flint8      System_ModbusBaud
 flint8      System_ModbusParity
+flint32     System_ModbusTimeout
 
 flstring    System_Rly1Name[NAMESIZE]
 flstring    System_Rly1Bool[BOOLSIZE]
@@ -2512,7 +2513,7 @@ thread main(const)
 	if initControl != AppVersion Init()		; init module if different from app version
 ;	Init()									; uncomment this line to force init
 	
-;    x = system.InhibitUSBLock                  ; NOT RECOMMENDED, uncomment to allow config pages when USB is unplugged. This exposes the config pages makes the system vunerable
+    x = system.InhibitUSBLock                  ; NOT RECOMMENDED, uncomment to allow config pages when USB is unplugged. This exposes the config pages makes the system vunerable
 
 	if System_RLY_PUR&0x00000001 Rly1 = RelayStore[0]		; restore relay states on power up
 	if System_RLY_PUR&0x00000002 Rly2 = RelayStore[1]
@@ -2792,6 +2793,7 @@ function Init()
     System_ModbusUID = 1
     System_ModbusBaud = 1               ; 9600
     System_ModbusParity = 1             ; even
+	System_ModbusTimeout = 10 			; 100ms default (in units of 10ms)
 
     System_Rly1Name = "Relay 1"
     System_Rly2Name = "Relay 2"
@@ -4959,9 +4961,9 @@ endfunction
 
 function waitModbusResponse()
 int32 i
-    for i = 1 to 30
+    for i = 1 to System_ModbusTimeout
         if RS485.BytesToRead>0 return
-        threadsleep 10                                                  ;wait up to 300mS for intial Modbus response
+        threadsleep 10                                                  ;wait up to System_ModbusTimeout*10 ms for intial Modbus response
     next
 endfunction
 

--- a/app-dS2832-v4-14.dsi
+++ b/app-dS2832-v4-14.dsi
@@ -4959,9 +4959,9 @@ endfunction
 
 function waitModbusResponse()
 int32 i
-    for i = 1 to 10
+    for i = 1 to 30
         if RS485.BytesToRead>0 return
-        threadsleep 10                                                  ;wait up to 100mS for intial Modbus response
+        threadsleep 10                                                  ;wait up to 300mS for intial Modbus response
     next
 endfunction
 

--- a/app-dS2832-v4-14.dsi
+++ b/app-dS2832-v4-14.dsi
@@ -2513,7 +2513,7 @@ thread main(const)
 	if initControl != AppVersion Init()		; init module if different from app version
 ;	Init()									; uncomment this line to force init
 	
-    x = system.InhibitUSBLock                  ; NOT RECOMMENDED, uncomment to allow config pages when USB is unplugged. This exposes the config pages makes the system vunerable
+    x = system.InhibitUSBLock                  ; NOT RECOMMENDED, uncomment to allow config pages when USB is unplugged. This exposes the config pages makes the system vulnerable
 
 	if System_RLY_PUR&0x00000001 Rly1 = RelayStore[0]		; restore relay states on power up
 	if System_RLY_PUR&0x00000002 Rly2 = RelayStore[1]

--- a/app-dS2832-v4-14.dsj
+++ b/app-dS2832-v4-14.dsj
@@ -1,1 +1,0 @@
-{"web":"\/webpage","name":"app-dS2832-v4-14","files":[{"file":"app-dS2832-v4-14.dsi","compile":true}],"active":"app-dS2832-v4-14.dsi","version":"1","editors":["app-dS2832-v4-14.dsi,224"]}

--- a/webpage/._config3.htm
+++ b/webpage/._config3.htm
@@ -93,6 +93,13 @@
                             <option value='2'>Odd</option>
                         </select>
                     </div>
+					<div>
+					  <div class="item-line">Modbus Slave Timeout (ms)</div>
+					  <input style = "margin-top:20px" type="range" id="ModbusTimeout" min="1" max="300" step="1"
+							 oninput="document.getElementById('ModbusTimeoutValue').innerText = (this.value * 10)"
+							 onchange="newAJAXCommand('dscript.cgi?System_ModbusTimeout=' + (this.value));" />
+					  <span id="ModbusTimeoutValue">100</span> ms
+					</div>					
                 </div>
             </div>
         </div>
@@ -115,8 +122,11 @@ if(document.getElementById("ModBusChkBox").checked == true) {
     document.getElementById('SystemPINnumber').disabled = true;
 }
 else document.getElementById('mbus').style.display = 'none';
+
 document.getElementById('baud').value = ~System_ModbusBaud~;
 document.getElementById('Parity').value = ~System_ModbusParity~;
+document.getElementById('ModbusTimeout').value = (~System_ModbusTimeout~);
+document.getElementById('ModbusTimeoutValue').innerText = (~System_ModbusTimeout~)*10;
 
 if(document.getElementById("AsciiChkBox").checked == true) {
         document.getElementById('SystemAESkey').disabled = true;
@@ -134,6 +144,10 @@ if(document.getElementById("AESChkBox").checked == true) {
 
 if(document.getElementById("PhoneChkBox").checked == true) {
         document.getElementById('SystemAESkey').disabled = true;
+}
+
+function NotifyText(x) {
+    document.getElementById('help').innerHTML = "<br>Event Notification<br><br>Send an event notification to a server when any specified Relay or Input changes state.<br><br>";
 }
 
 function dSxText(x) {

--- a/webpage/_config3.htm
+++ b/webpage/_config3.htm
@@ -93,13 +93,13 @@
                             <option value='2'>Odd</option>
                         </select>
                     </div>
-					<div>
-					  <div class="item-line">Modbus Slave Timeout (ms)</div>
-					  <input style = "margin-top:20px" type="range" id="ModbusTimeout" min="1" max="300" step="1"
-							 oninput="document.getElementById('ModbusTimeoutValue').innerText = (this.value * 10)"
-							 onchange="newAJAXCommand('dscript.cgi?System_ModbusTimeout=' + (this.value));" />
-					  <span id="ModbusTimeoutValue">100</span> ms
-					</div>					
+                    <div>
+                      <div class="item-line">Modbus Slave Timeout (ms)</div>
+                      <input style = "margin-top:20px" type="range" id="ModbusTimeout" min="1" max="300" step="1"
+                             oninput="document.getElementById('ModbusTimeoutValue').innerText = (this.value * 10)"
+                             onchange="newAJAXCommand('dscript.cgi?System_ModbusTimeout=' + (this.value));" />
+                      <span id="ModbusTimeoutValue">100</span> ms
+                    </div>					
                 </div>
             </div>
         </div>

--- a/webpage/_config3.htm
+++ b/webpage/_config3.htm
@@ -95,7 +95,7 @@
                     </div>
 					<div>
 					  <div class="item-line">Modbus Slave Timeout (ms)</div>
-					  <input style = "margin-top:20px" type="range" id="SystemModbusTimeout" min="1" max="300" step="1"
+					  <input style = "margin-top:20px" type="range" id="ModbusTimeout" min="1" max="300" step="1"
 							 oninput="document.getElementById('ModbusTimeoutValue').innerText = (this.value * 10)"
 							 onchange="newAJAXCommand('dscript.cgi?System_ModbusTimeout=' + (this.value));" />
 					  <span id="ModbusTimeoutValue">100</span> ms
@@ -122,8 +122,11 @@ if(document.getElementById("ModBusChkBox").checked == true) {
     document.getElementById('SystemPINnumber').disabled = true;
 }
 else document.getElementById('mbus').style.display = 'none';
+
 document.getElementById('baud').value = ~System_ModbusBaud~;
 document.getElementById('Parity').value = ~System_ModbusParity~;
+document.getElementById('ModbusTimeout').value = (~System_ModbusTimeout~)*10;
+document.getElementById('ModbusTimeoutValue').innerText = (~System_ModbusTimeout~)*10;
 
 if(document.getElementById("AsciiChkBox").checked == true) {
         document.getElementById('SystemAESkey').disabled = true;

--- a/webpage/_config3.htm
+++ b/webpage/_config3.htm
@@ -125,7 +125,7 @@ else document.getElementById('mbus').style.display = 'none';
 
 document.getElementById('baud').value = ~System_ModbusBaud~;
 document.getElementById('Parity').value = ~System_ModbusParity~;
-document.getElementById('ModbusTimeout').value = (~System_ModbusTimeout~)*10;
+document.getElementById('ModbusTimeout').value = (~System_ModbusTimeout~);
 document.getElementById('ModbusTimeoutValue').innerText = (~System_ModbusTimeout~)*10;
 
 if(document.getElementById("AsciiChkBox").checked == true) {

--- a/webpage/_config3.htm
+++ b/webpage/_config3.htm
@@ -93,6 +93,13 @@
                             <option value='2'>Odd</option>
                         </select>
                     </div>
+					<div>
+					  <div class="item-line">Modbus Slave Timeout (ms)</div>
+					  <input style = "margin-top:20px" type="range" id="SystemModbusTimeout" min="1" max="300" step="1"
+							 oninput="document.getElementById('ModbusTimeoutValue').innerText = (this.value * 10)"
+							 onchange="newAJAXCommand('dscript.cgi?System_ModbusTimeout=' + (this.value));" />
+					  <span id="ModbusTimeoutValue">100</span> ms
+					</div>					
                 </div>
             </div>
         </div>


### PR DESCRIPTION
One of my modbus devices was responding later than the standard delay of 100ms in the dScript default application. I added a Modbus Timeout slider which configures the maximum waiting time before a modbus error 11 is thrown.